### PR TITLE
Adjust .gitignore for assets folder;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /LovrApp/Projects/Android/.externalNativeBuild
 /LovrApp/Projects/Android/build
 /LovrApp/Projects/Android/.gradle
-/LovrApp/assets/oculussig*
 /LovrApp/Projects/Android/android.debug.keystore
 /build
 /cmakelib/.externalNativeBuild

--- a/LovrApp/assets/.gitignore
+++ b/LovrApp/assets/.gitignore
@@ -1,0 +1,2 @@
+# You can put files for your lovr project in this folder
+*


### PR DESCRIPTION
This is a proposal to ignore files in the `LovrApp/assets` folder so they don't clutter `git status`.  Additionally, the presence of a `.gitignore` file can serve the purpose of the existing "donotdelete" file so that git tracks the folder.

I also removed the root level ignore for the `oculussig` files since the new gitignore takes care of that.