### PR TITLE
Pass displayFrequency to bridge

### DIFF
--- a/LovrApp/Src/LovrApp_NativeActivity.cpp
+++ b/LovrApp/Src/LovrApp_NativeActivity.cpp
@@ -1465,6 +1465,7 @@ void android_main( struct android_app * app )
 			// Possibly convince lovr main project to accept a dichotomy between 'display size' and 'recommended renderbuffer size'?
 			bridgeData.suggestedEyeTexture.width = vrapi_GetSystemPropertyInt( &appState.Java, VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH );
 			bridgeData.suggestedEyeTexture.height = vrapi_GetSystemPropertyInt( &appState.Java, VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_HEIGHT );
+			bridgeData.displayFrequency = (float) vrapi_GetSystemPropertyInt( &appState.Java, VRAPI_SYS_PROP_DISPLAY_REFRESH_RATE );
 			bridgeData.zeroDisplayTime = vrapi_GetPredictedDisplayTime( appState.Ovr, 0 );
 
 			// What type of device is this? Collapse device ranges into general types


### PR DESCRIPTION
For this to compile, a lovr bump is required to get the new `displayFrequency` field.  See https://github.com/bjornbytes/lovr/pull/216.  I could do that on this PR after merging the lovr change.