### PR TITLE
Pass bounds dimensions across bridge

### DIFF
--- a/LovrApp/Src/LovrApp_NativeActivity.cpp
+++ b/LovrApp/Src/LovrApp_NativeActivity.cpp
@@ -1522,6 +1522,14 @@ void android_main( struct android_app * app )
 
 		updateData.displayTime = predictedDisplayTime;
 
+		// Boundary
+		ovrPosef boundsPose;
+		ovrVector3f boundsScale;
+		if (vrapi_GetBoundaryOrientedBoundingBox(appState.Ovr, &boundsPose, &boundsScale) == ovrSuccess) {
+			updateData.boundsWidth = boundsScale.x * 2.f;
+			updateData.boundsDepth = boundsScale.z * 2.f;
+		}
+
 		ovrApp_HandleInput( &appState, updateData, predictedDisplayTime );
 
 		// Render eye images and setup the primary layer using ovrTracking2.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Known limitations and planned improvement for LovrApp and Lovr for Oculus Mobile
 - Avatar SDK support (to display controller model) should be added
 - "Focus" events should be issued on pause and resume
 - lovr.conf MSAA setting is ignored
-- The play bounds feature is not supported, but could be
 - Display masks are not supported, but could be
 - Microphones are not supported, but could be
 - It would be nice to have Windows build instructions above


### PR DESCRIPTION
This is for `lovr.headset.getBoundsDimensions`.

I couldn't figure out how to expose `lovr.headset.getBoundsGeometry` (the list of points) in a satisfactory way.  Started worrying about copies/allocations, may take another look later.

See https://github.com/bjornbytes/lovr/pull/218 for the consumer of this