### PR TITLE
Hand meshes;

### DIFF
--- a/LovrApp/Projects/Android/jni/Android.mk
+++ b/LovrApp/Projects/Android/jni/Android.mk
@@ -25,6 +25,8 @@ include $(CLEAR_VARS)
 LOCAL_C_INCLUDES += ../../../cmakelib \
   					$(LOCAL_PATH)/../../../../1stParty/OVR/Include \
   					$(LOCAL_PATH)/../../../../VrSamples/VrHands/Src
+LOCAL_C_INCLUDES += ../../../cmakelib/lovr/src
+LOCAL_C_INCLUDES += ../../../cmakelib/lovr/src/modules
 
 LOCAL_MODULE			:= lovractivity
 LOCAL_CFLAGS			:= -Werror


### PR DESCRIPTION
Here is what I added to get `lovr.headset.newModel` working to expose the Oculus hand meshes.

It requires 3 fields added to the bridge; still working on cleaning that up.

I passed bones over as local quaternions instead of world poses.  Currently I feel this approach should be preferred over the use of `OVRFW::ovrHandModel` because it only requires half as much data, doesn't require any conversions from what vrapi returns, and reduces the number of different pieces of the SDK we depend on (esp. the C++ pieces >_>).  If this seems like a good idea I could add a commit to fully switch over to the quaternion path and remove the world space poses.

A potentially questionable change is adding the lovr include paths to the `LOCAL_C_INCLUDES` and using `ModelData` and `lovrAlloc` in NativeActivity.  This seemed like the easiest approach, but another idea might be to pass some agnostic `bridgeLovrHandModel` struct over the bridge which would allow `ModelData` to be better quarantined in the lovr repo.